### PR TITLE
Fix empty map casting

### DIFF
--- a/lib/src/classes/feature.dart
+++ b/lib/src/classes/feature.dart
@@ -48,7 +48,7 @@ class GeoJSONFeature implements GeoJSON {
     assert(map['geometry'] is Map, 'There MUST be geometry object.');
     return GeoJSONFeature(
       GeoJSONGeometry.fromMap(map['geometry']),
-      properties: map['properties'],
+      properties: Map.castFrom(map['properties']),
       id: map['id'],
       title: map['title'],
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: geojson_vi
 description: GeoJSON package for Dart and Flutter developers to create, read, search, update and delete the geospatial data interchange format (GIS data).
 
-version: 2.0.3
+version: 2.0.4
 homepage: https://github.com/chuyentt/geojson_vi
 
 environment:


### PR DESCRIPTION
## About the issue

I found some interesting issue today that breaks behavior of `GeoJSONFeature.fromMap(...)`
The issue is happening because empty map like `{}` has type `_InternalLinkedHashMap` and not `Map` (like maps from JSON converting) and so  feature with empty map in "properties" field creates this error:
```
Unhandled exception:
type '_InternalLinkedHashMap<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>?'
#0      new GeoJSONFeature.fromMap                  package:geojson_vi/…/classes/feature.dart:51
```
but map like `<String, dynamic>{}` works well because it has type `Map<String, dynamic>` and it is ok. Omitting "properties" field and non empty maps works well too.

Issue also happens with `GeoJSONFeatureCollection.fromMap(...)` since it uses `GeoJSONFeature.fromMap(...)`.

## Example

```dart
import 'package:geojson_vi/geojson_vi.dart';

void main() async {
  final features = {
    "type": "Feature",
    "properties": {},
    "geometry": {
      "type": "Polygon",
      "coordinates": [
        [
          [34.453125, 54.007768],
          [40.78125, 54.007768],
          [40.78125, 57.326521],
          [34.453125, 57.326521],
          [34.453125, 54.007768],
        ],
      ],
    },
  };
  final collectionGeoJSON = GeoJSONFeature.fromMap(features);
}
```

## Way to fix it

It can be fixed quite easily with explicit map casting using `Map.castFrom(...)` so empty "properties" map will work well too, so I made this fix in this pull request: In file **lib/src/classes/feature.dart** in line 51 I changed `map['properties']` to `Map.castFrom(map['properties'])` so it always will be converted to `Map<String, dynamic>` before passing into `GeoJSONFeature` constructor.