### PR TITLE
Fix casting null value of "properties" to map

### DIFF
--- a/lib/src/classes/feature.dart
+++ b/lib/src/classes/feature.dart
@@ -48,7 +48,8 @@ class GeoJSONFeature implements GeoJSON {
     assert(map['geometry'] is Map, 'There MUST be geometry object.');
     return GeoJSONFeature(
       GeoJSONGeometry.fromMap(map['geometry']),
-      properties: Map.castFrom(map['properties']),
+      properties:
+          map['properties'] != null ? Map.castFrom(map['properties']) : null,
       id: map['id'],
       title: map['title'],
     );


### PR DESCRIPTION
I did pull request #17 more than month ago, and it really fixed problems described there, but after some recent experiments with GeoJSON in Dart I encountered another problem I created with this pull request: value `null` or just no value throws an error while creating GeoJSON Feature from Map.

It happens because method `Map.castFrom` requires a Map, but `map['properties']` can contain also `null` value and it shouldn't throw an error in this case, because "properties" is not required by GeoJSON Feature schema. So I changed this:
```dart
Map.castFrom(map['properties'])
```
into this:
```dart
map['properties'] != null ? Map.castFrom(map['properties']) : null
```
It checks if original "properties" field is not null and if it is so, `Map` will returned, otherwise it will have `null` value. This fixes such problem without reverting my previous pull request, and I hope all problems about this field is over now.

Here is my simple test for checking such casting:
```dart
import 'package:geojson_vi/geojson_vi.dart';
import 'package:test/test.dart';

void main(List<String> arguments) {
  test('Empty map', () {
    final geojsonMap = {
      "type": "Feature",
      "properties": {},
      "geometry": {
        "type": "Point",
        "coordinates": [37.610106468200684, 55.751245591507605]
      }
    };
    expect(GeoJSONFeature.fromMap(geojsonMap).properties, {});
  });

  test('No value', () {
    final geojsonMap = {
      "type": "Feature",
      "geometry": {
        "type": "Point",
        "coordinates": [37.610106468200684, 55.751245591507605]
      }
    };
    expect(GeoJSONFeature.fromMap(geojsonMap).properties, null);
  });

  test('Correct map', () {
    final geojsonMap = {
      "type": "Feature",
      "properties": {"a": "b"},
      "geometry": {
        "type": "Point",
        "coordinates": [37.610106468200684, 55.751245591507605]
      }
    };
    expect(GeoJSONFeature.fromMap(geojsonMap).properties, {'a': 'b'});
  });

  test('Null value', () {
    final geojsonMap = {
      "type": "Feature",
      "properties": null,
      "geometry": {
        "type": "Point",
        "coordinates": [37.610106468200684, 55.751245591507605]
      }
    };
    expect(GeoJSONFeature.fromMap(geojsonMap).properties, null);
  });
}
```