### PR TITLE
Replace assertions with new GeoJSONFormatException

### DIFF
--- a/lib/src/classes/feature.dart
+++ b/lib/src/classes/feature.dart
@@ -38,11 +38,13 @@ class GeoJSONFeature implements GeoJSON {
         _bbox = geometry?.bbox;
 
   /// The constructor from map
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONFeature.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['Feature'].contains(map['type']), 'Invalid type');
-    assert(
-        map.containsKey('geometry'), 'There MUST be contains key `geometry`');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(['Feature'].contains(map['type']), 'Invalid type', map['type']);
+    _assert(map.containsKey('geometry'),
+        'There MUST be contains key `geometry`', map);
     final geometry = map['geometry'] != null
         ? GeoJSONGeometry.fromMap(map['geometry'])
         : null;
@@ -56,6 +58,9 @@ class GeoJSONFeature implements GeoJSON {
   }
 
   /// The constructor from JSON string
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONFeature.fromJSON(String source) =>
       GeoJSONFeature.fromMap(json.decode(source));
 

--- a/lib/src/classes/feature_collection.dart
+++ b/lib/src/classes/feature_collection.dart
@@ -172,12 +172,16 @@ class GeoJSONFeatureCollection implements GeoJSON {
   }
 
   /// The constructor from map.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONFeatureCollection.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['FeatureCollection'].contains(map['type']), 'Invalid type');
-    assert(
-        map.containsKey('features'), 'There MUST be contains key `features`');
-    assert(map['features'] is List, 'There MUST be an array of features.');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(['FeatureCollection'].contains(map['type']), 'Invalid type',
+        map['type']);
+    _assert(map.containsKey('features'),
+        'There MUST be contains key `features`', map);
+    _assert(map['features'] is List, 'There MUST be an array of features.',
+        map['features']);
     final value = map['features'] as List;
     final fs = <GeoJSONFeature>[];
     Future.forEach(value, (map) {
@@ -187,6 +191,9 @@ class GeoJSONFeatureCollection implements GeoJSON {
   }
 
   /// The constructor from JSON string.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONFeatureCollection.fromJSON(String source) =>
       GeoJSONFeatureCollection.fromMap(json.decode(source));
 

--- a/lib/src/classes/geometry.dart
+++ b/lib/src/classes/geometry.dart
@@ -27,9 +27,11 @@ abstract class GeoJSONGeometry implements GeoJSON {
   ///
   /// The Map must contain a 'type' key with one of the valid GeoJSON Geometry
   /// types.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONGeometry.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(
         [
           'Point',
           'MultiPoint',
@@ -39,7 +41,8 @@ abstract class GeoJSONGeometry implements GeoJSON {
           'MultiPolygon',
           'GeometryCollection'
         ].contains(map['type']),
-        'Invalid type');
+        'Invalid type',
+        map['type']);
     return GeoJSON.fromMap(map) as GeoJSONGeometry;
   }
 
@@ -47,6 +50,9 @@ abstract class GeoJSONGeometry implements GeoJSON {
   ///
   /// The JSON string must represent a Map containing a 'type' key with one of
   /// the valid GeoJSON Geometry types.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONGeometry.fromJSON(String source) =>
       GeoJSONGeometry.fromMap(json.decode(source));
 

--- a/lib/src/classes/geometry_collection.dart
+++ b/lib/src/classes/geometry_collection.dart
@@ -46,12 +46,16 @@ class GeoJSONGeometryCollection implements GeoJSONGeometry {
   /// Constructs a new Geometry Collection from a Map object.
   ///
   /// The Map must represent a valid Geometry Collection.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONGeometryCollection.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['GeometryCollection'].contains(map['type']), 'Invalid type');
-    assert(map.containsKey('geometries'),
-        'There MUST be contains key `geometries`');
-    assert(map['geometries'] is List, 'There MUST be array of the geometry.');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(['GeometryCollection'].contains(map['type']), 'Invalid type',
+        map['type']);
+    _assert(map.containsKey('geometries'),
+        'There MUST be contains key `geometries`', map);
+    _assert(map['geometries'] is List, 'There MUST be array of the geometry.',
+        map['geometries']);
     final value = map['geometries'];
     final geoms = <GeoJSONGeometry>[];
     value.forEach((map) {
@@ -63,6 +67,9 @@ class GeoJSONGeometryCollection implements GeoJSONGeometry {
   /// Constructs a new Geometry Collection from a JSON string.
   ///
   /// The JSON string must represent a valid Geometry Collection.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONGeometryCollection.fromJSON(String source) =>
       GeoJSONGeometryCollection.fromMap(json.decode(source));
 

--- a/lib/src/classes/line_string.dart
+++ b/lib/src/classes/line_string.dart
@@ -50,23 +50,29 @@ class GeoJSONLineString implements GeoJSONGeometry {
   }
 
   /// Constructs a GeoJSONLineString from the provided list of [coordinates].
-  GeoJSONLineString(this.coordinates)
-      : assert(coordinates.length >= 2,
-            'The coordinates MUST be two or more positions');
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
+  GeoJSONLineString(this.coordinates) {
+    _assert(coordinates.length >= 2,
+        'The coordinates MUST be two or more positions', coordinates);
+  }
 
   /// Constructs a GeoJSONLineString from a Map.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONLineString.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['LineString'].contains(map['type']), 'Invalid type');
-    assert(map.containsKey('coordinates'),
-        'There MUST be contains key `coordinates`');
-    assert(map['coordinates'] is List,
-        'There MUST be array of two or more positions.');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(['LineString'].contains(map['type']), 'Invalid type', map['type']);
+    _assert(map.containsKey('coordinates'),
+        'There MUST be contains key `coordinates`', map);
+    _assert(map['coordinates'] is List,
+        'There MUST be array of two or more positions.', map['coordinates']);
     final lll = map['coordinates'];
     final coordinates = <List<double>>[];
     lll.forEach((ll) {
-      assert(ll is List, 'There MUST be List');
-      assert((ll as List).length > 1, 'There MUST be two or more element');
+      _assert(ll is List, 'There MUST be List', [map, lll]);
+      _assert((ll as List).length > 1, 'There MUST be two or more element',
+          [map, lll, ll]);
       final pos = ll.map((e) => e.toDouble()).cast<double>().toList();
       coordinates.add(pos);
     });
@@ -74,6 +80,9 @@ class GeoJSONLineString implements GeoJSONGeometry {
   }
 
   /// Constructs a GeoJSONLineString from a JSON string.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONLineString.fromJSON(String source) =>
       GeoJSONLineString.fromMap(json.decode(source));
 

--- a/lib/src/classes/multi_line_string.dart
+++ b/lib/src/classes/multi_line_string.dart
@@ -47,29 +47,38 @@ class GeoJSONMultiLineString implements GeoJSONGeometry {
   /// Creates a new GeoJSONMultiLineString object with the given [coordinates].
   ///
   /// The [coordinates] must represent one or more valid LineString coordinates.
-  GeoJSONMultiLineString(this.coordinates)
-      : assert(coordinates.isNotEmpty,
-            'The coordinates MUST be one or more elements');
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
+  GeoJSONMultiLineString(this.coordinates) {
+    _assert(coordinates.isNotEmpty,
+        'The coordinates MUST be one or more elements', coordinates);
+  }
 
   /// Creates a new GeoJSONMultiLineString object from a map.
   ///
   /// The map must include a 'type' key with the value 'MultiLineString' and
   /// a 'coordinates' key with an array of linear ring coordinate arrays.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONMultiLineString.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['MultiLineString'].contains(map['type']), 'Invalid type');
-    assert(map.containsKey('coordinates'),
-        'There MUST be contains key `coordinates`');
-    assert(map['coordinates'] is List,
-        'There MUST be array of linear ring coordinate arrays.');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(
+        ['MultiLineString'].contains(map['type']), 'Invalid type', map['type']);
+    _assert(map.containsKey('coordinates'),
+        'There MUST be contains key `coordinates`', map);
+    _assert(
+        map['coordinates'] is List,
+        'There MUST be array of linear ring coordinate arrays.',
+        map['coordinates']);
     final llll = map['coordinates'];
     final coords = <List<List<double>>>[];
     llll.forEach((lll) {
-      assert(lll is List, 'There MUST be List');
+      _assert(lll is List, 'There MUST be List', [map, lll]);
       final rings = <List<double>>[];
       lll.forEach((ll) {
-        assert(ll is List, 'There MUST be List');
-        assert((ll as List).length > 1, 'There MUST be two or more element');
+        _assert(ll is List, 'There MUST be List', [map, ll]);
+        _assert((ll as List).length > 1, 'There MUST be two or more element',
+            [map, ll]);
         final pos = ll.map((e) => e.toDouble()).cast<double>().toList();
         rings.add(pos);
       });
@@ -81,6 +90,9 @@ class GeoJSONMultiLineString implements GeoJSONGeometry {
   /// Creates a new GeoJSONMultiLineString object from a JSON string.
   ///
   /// The JSON string must represent a valid GeoJSON MultiLineString object.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONMultiLineString.fromJSON(String source) =>
       GeoJSONMultiLineString.fromMap(json.decode(source));
 

--- a/lib/src/classes/multi_point.dart
+++ b/lib/src/classes/multi_point.dart
@@ -44,24 +44,32 @@ class GeoJSONMultiPoint implements GeoJSONGeometry {
   double get distance => 0.0;
 
   /// Constructs a GeoJSONMultiPoint from the provided list of [coordinates].
-  GeoJSONMultiPoint(this.coordinates)
-      : assert(
-            coordinates.isNotEmpty,
-            'The coordinates is List<List<double>>. '
-            'There MUST be one or more elements');
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
+  GeoJSONMultiPoint(this.coordinates) {
+    _assert(
+        coordinates.isNotEmpty,
+        'The coordinates is List<List<double>>. '
+        'There MUST be one or more elements',
+        coordinates);
+  }
 
   /// Constructs a GeoJSONMultiPoint from a Map.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONMultiPoint.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['MultiPoint'].contains(map['type']), 'Invalid type');
-    assert(map.containsKey('coordinates'),
-        'There MUST be contains key `coordinates`');
-    assert(map['coordinates'] is List, 'There MUST be array of positions.');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(['MultiPoint'].contains(map['type']), 'Invalid type', map['type']);
+    _assert(map.containsKey('coordinates'),
+        'There MUST be contains key `coordinates`', map);
+    _assert(map['coordinates'] is List, 'There MUST be array of positions.',
+        map['coordinates']);
     final lll = map['coordinates'];
     final coords = <List<double>>[];
     lll.forEach((ll) {
-      assert(ll is List, 'There MUST be List');
-      assert((ll as List).length > 1, 'There MUST be two or more element');
+      _assert(ll is List, 'There MUST be List', [map, ll]);
+      _assert((ll as List).length > 1, 'There MUST be two or more element',
+          [map, ll]);
       final pos = ll.map((e) => e.toDouble()).cast<double>().toList();
       coords.add(pos);
     });
@@ -69,6 +77,9 @@ class GeoJSONMultiPoint implements GeoJSONGeometry {
   }
 
   /// Constructs a GeoJSONMultiPoint from a JSON string.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONMultiPoint.fromJSON(String source) =>
       GeoJSONMultiPoint.fromMap(json.decode(source));
 

--- a/lib/src/classes/multi_polygon.dart
+++ b/lib/src/classes/multi_polygon.dart
@@ -56,32 +56,41 @@ class GeoJSONMultiPolygon implements GeoJSONGeometry {
   /// The [coordinates] should contain at least one Polygon, and each Polygon
   /// should contain at least two points (the start and end point of a linear
   /// ring).
-  GeoJSONMultiPolygon(this.coordinates)
-      : assert(coordinates.first.first.length >= 2,
-            'The coordinates MUST be two or more elements');
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
+  GeoJSONMultiPolygon(this.coordinates) {
+    _assert(coordinates.first.first.length >= 2,
+        'The coordinates MUST be two or more elements', coordinates);
+  }
 
   /// Constructs a GeoJSONMultiPolygon from a map.
   ///
   /// The map must contain a 'type' key with the value 'MultiPolygon', and a
   /// 'coordinates' key with the value being a list of Polygon coordinate arrays.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONMultiPolygon.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['MultiPolygon'].contains(map['type']), 'Invalid type');
-    assert(map.containsKey('coordinates'),
-        'There MUST be contains key `coordinates`');
-    assert(map['coordinates'] is List,
-        'There MUST be array of Polygon coordinate arrays.');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(
+        ['MultiPolygon'].contains(map['type']), 'Invalid type', map['type']);
+    _assert(map.containsKey('coordinates'),
+        'There MUST be contains key `coordinates`', map);
+    _assert(
+        map['coordinates'] is List,
+        'There MUST be array of Polygon coordinate arrays.',
+        map['coordinates']);
     final lllll = map['coordinates'];
     final coords = <List<List<List<double>>>>[];
     lllll.forEach((llll) {
       final polygon = <List<List<double>>>[];
-      assert(llll is List, 'There MUST be List');
+      _assert(llll is List, 'There MUST be List', [map, llll]);
       llll.forEach((lll) {
-        assert(lll is List, 'There MUST be List');
+        _assert(lll is List, 'There MUST be List', [map, lll]);
         final rings = <List<double>>[];
         lll.forEach((ll) {
-          assert(ll is List, 'There MUST be List');
-          assert((ll as List).length > 1, 'There MUST be two or more element');
+          _assert(ll is List, 'There MUST be List', [map, ll]);
+          _assert((ll as List).length > 1, 'There MUST be two or more element',
+              [map, ll]);
           final pos = ll.map((e) => e.toDouble()).cast<double>().toList();
           rings.add(pos);
         });
@@ -97,6 +106,9 @@ class GeoJSONMultiPolygon implements GeoJSONGeometry {
   /// The JSON string must represent a map containing a 'type' key with the
   /// value 'MultiPolygon', and a 'coordinates' key with the value being a list
   /// of Polygon coordinate arrays.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONMultiPolygon.fromJSON(String source) =>
       GeoJSONMultiPolygon.fromMap(json.decode(source));
 

--- a/lib/src/classes/point.dart
+++ b/lib/src/classes/point.dart
@@ -28,26 +28,36 @@ class GeoJSONPoint implements GeoJSONGeometry {
   double get distance => 0.0;
 
   /// Constructs a GeoJSONPoint from the provided list of [coordinates].
-  GeoJSONPoint(this.coordinates)
-      : assert(
-            coordinates.length >= 2,
-            'The coordinates is List<double>. '
-            'There MUST be two or more elements');
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
+  GeoJSONPoint(this.coordinates) {
+    _assert(
+        coordinates.length >= 2,
+        'The coordinates is List<double>. '
+        'There MUST be two or more elements',
+        coordinates);
+  }
 
   /// Constructs a GeoJSONPoint from a Map.
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONPoint.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['Point'].contains(map['type']), 'Invalid type');
-    assert(map.containsKey('coordinates'),
-        'There MUST be contains key `coordinates`');
-    assert(map['coordinates'] is List, 'There MUST be List of double');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(['Point'].contains(map['type']), 'Invalid type', map['type']);
+    _assert(map.containsKey('coordinates'),
+        'There MUST be contains key `coordinates`', map);
+    _assert(map['coordinates'] is List, 'There MUST be List of double',
+        map['coordinates']);
     final ll = map['coordinates'];
-    assert((ll as List).length > 1, 'There MUST be two or more element');
+    _assert((ll as List).length > 1, 'There MUST be two or more element', ll);
     final pos = ll.map((e) => e.toDouble()).cast<double>().toList();
     return GeoJSONPoint(pos);
   }
 
   /// Constructs a GeoJSONPoint from a JSON string.
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONPoint.fromJSON(String source) =>
       GeoJSONPoint.fromMap(json.decode(source));
 

--- a/lib/src/classes/polygon.dart
+++ b/lib/src/classes/polygon.dart
@@ -290,26 +290,34 @@ class GeoJSONPolygon implements GeoJSONGeometry {
   }
 
   /// The constructor for the [coordinates] member
-  GeoJSONPolygon(this.coordinates)
-      : assert(coordinates.isNotEmpty,
-            'The coordinates MUST be one or more elements');
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
+  GeoJSONPolygon(this.coordinates) {
+    _assert(coordinates.isNotEmpty,
+        'The coordinates MUST be one or more elements', coordinates);
+  }
 
   /// The constructor from map
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONPolygon.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(['Polygon'].contains(map['type']), 'Invalid type');
-    assert(map.containsKey('coordinates'),
-        'There MUST be contains key `coordinates`');
-    assert(map['coordinates'] is List,
-        'There MUST be array of linear ring coordinate arrays.');
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(['Polygon'].contains(map['type']), 'Invalid type', map['type']);
+    _assert(map.containsKey('coordinates'),
+        'There MUST be contains key `coordinates`', map);
+    _assert(
+        map['coordinates'] is List,
+        'There MUST be array of linear ring coordinate arrays.',
+        map['coordinates']);
     final llll = map['coordinates'];
     final coords = <List<List<double>>>[];
     llll.forEach((lll) {
-      assert(lll is List, 'There MUST be List');
+      _assert(lll is List, 'There MUST be List', [map, lll]);
       final rings = <List<double>>[];
       lll.forEach((ll) {
-        assert(ll is List, 'There MUST be List');
-        assert((ll as List).length > 1, 'There MUST be two or more element');
+        _assert(ll is List, 'There MUST be List', [map, ll]);
+        _assert((ll as List).length > 1, 'There MUST be two or more element',
+            [map, ll]);
         final pos = ll.map((e) => e.toDouble()).cast<double>().toList();
         rings.add(pos);
       });
@@ -319,6 +327,9 @@ class GeoJSONPolygon implements GeoJSONGeometry {
   }
 
   /// The constructor from JSON string
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSONPolygon.fromJSON(String source) =>
       GeoJSONPolygon.fromMap(json.decode(source));
 

--- a/lib/src/geojson_vi_base.dart
+++ b/lib/src/geojson_vi_base.dart
@@ -1,5 +1,13 @@
 part of '../geojson_vi.dart';
 
+class GeoJSONFormatException extends FormatException {
+  GeoJSONFormatException(msg, [source]) : super(msg, source);
+}
+
+void _assert(condition, msg, [source]) {
+  if (!condition) throw GeoJSONFormatException(msg, source);
+}
+
 /// `GeoJSON` is an abstract class representing a geospatial data interchange
 /// format.
 ///
@@ -24,9 +32,11 @@ abstract class GeoJSON {
   /// The value of the type member must be one of:
   /// "FeatureCollection", "Feature", "Point", "MultiPoint", "LineString",
   /// "MultiLineString", "Polygon", "MultiPolygon", "GeometryCollection"
+  ///
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSON.fromMap(Map<String, dynamic> map) {
-    assert(map.containsKey('type'), 'There MUST be contains key `type`');
-    assert(
+    _assert(map.containsKey('type'), 'There MUST be contains key `type`', map);
+    _assert(
         [
           'FeatureCollection',
           'Feature',
@@ -38,7 +48,8 @@ abstract class GeoJSON {
           'MultiPolygon',
           'GeometryCollection'
         ].contains(map['type']),
-        'Invalid type');
+        'Invalid type',
+        map['type']);
 
     final type = map['type'];
     late GeoJSON instance;
@@ -75,6 +86,9 @@ abstract class GeoJSON {
   }
 
   /// Constructs a GeoJSON object from a JSON string [source].
+  ///
+  /// Throws [FormatException] if argument is not valid JSON
+  /// Throws [GeoJSONFormatException] if argument is not valid GeoJSON
   factory GeoJSON.fromJSON(String source) =>
       GeoJSON.fromMap(json.decode(source));
 


### PR DESCRIPTION
Currently, handling user-supplied GeoJSON is very difficult due to the use of assertions throughout the codebase to guard against invalid inputs. Validation on the user side is impractical as it requires rewriting basically all of the parsing code. 

I propose creating a new `GeoJSONFormatException` to be thrown by `fromMap` and `fromJSON` in the event of invalid GeoJSON.